### PR TITLE
CI-501 adjustments

### DIFF
--- a/src/SFA.DAS.EmployerFinance.Domain.UnitTests/ExpiredFunds/WhenComparingCalendarPeriods.cs
+++ b/src/SFA.DAS.EmployerFinance.Domain.UnitTests/ExpiredFunds/WhenComparingCalendarPeriods.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using SFA.DAS.EmployerFinance.Domain.ExpiredFunds;
 
 namespace SFA.DAS.EmployerFinance.Domain.UnitTests.ExpiredFunds
@@ -67,6 +68,24 @@ namespace SFA.DAS.EmployerFinance.Domain.UnitTests.ExpiredFunds
             var actual = calendarPeriod1 < calendarPeriod2;
 
             //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestCase("2018-1", "2017-12", true)]
+        [TestCase("2018-1", "2018-2", true)]
+        [TestCase("2018-8", "2018-9", true)]
+        [TestCase("2018-3", "2018-4", false)]
+        [TestCase("2017-3", "2018-5", false)]
+        public void Then_The_Tax_Years_Are_Compared_Correctly(string start, string end, bool expected)
+        {
+            //Arrange
+            var startDate = new CalendarPeriod(Convert.ToInt32(start.Split('-')[0]), Convert.ToInt32(start.Split('-')[1]));
+            var endDate = new CalendarPeriod(Convert.ToInt32(end.Split('-')[0]), Convert.ToInt32(end.Split('-')[1]));
+
+
+            //Act
+            var actual = startDate.AreSameTaxYear(endDate);
+
             Assert.AreEqual(expected, actual);
         }
     }

--- a/src/SFA.DAS.EmployerFinance.Domain/ExpiredFunds/CalendarPeriod.cs
+++ b/src/SFA.DAS.EmployerFinance.Domain/ExpiredFunds/CalendarPeriod.cs
@@ -38,6 +38,27 @@ namespace SFA.DAS.EmployerFinance.Domain.ExpiredFunds
             return Compare(period1, period2) >= 0;
         }
 
+        public bool AreSameTaxYear(CalendarPeriod compareTo)
+        {
+            return CheckPeriodsAreInSameTaxYear(new DateTime(Year, Month, 1), new DateTime(compareTo.Year, compareTo.Month, 1));
+        }
+
+        private static bool CheckPeriodsAreInSameTaxYear(DateTime firstPeriod, DateTime secondPeriod)
+        {
+            var startPeriodTaxYear = GetTaxYearFromDate(firstPeriod);
+
+            var endPeriodTaxYear = GetTaxYearFromDate(secondPeriod);
+
+            return startPeriodTaxYear == endPeriodTaxYear;
+        }
+
+        private static int GetTaxYearFromDate(DateTime firstPeriod)
+        {
+            return firstPeriod.Month >= 1 && firstPeriod.Month < 4
+                ? firstPeriod.Year -1
+                : firstPeriod.Year;
+        }
+
         private static int Compare(CalendarPeriod calendarPeriod1, CalendarPeriod calendarPeriod2)
         {
             if (calendarPeriod1 == null || calendarPeriod2 == null)

--- a/src/SFA.DAS.EmployerFinance.Domain/ExpiredFunds/IExpiredFunds.cs
+++ b/src/SFA.DAS.EmployerFinance.Domain/ExpiredFunds/IExpiredFunds.cs
@@ -5,7 +5,7 @@ namespace SFA.DAS.EmployerFinance.Domain.ExpiredFunds
 {
     public interface IExpiredFunds
     {
-        decimal GetExpiringFundsByDate(Dictionary<CalendarPeriod, decimal> fundsIn, Dictionary<CalendarPeriod, decimal> fundsOut, DateTime date, Dictionary<CalendarPeriod, decimal> expired, int expiryPeriod);
-        Dictionary<CalendarPeriod, decimal> GetExpiringFunds(Dictionary<CalendarPeriod, decimal> fundsIn, Dictionary<CalendarPeriod, decimal> fundsOut, Dictionary<CalendarPeriod, decimal> expired, int expiryPeriod);
+        decimal GetExpiringFundsByDate(IDictionary<CalendarPeriod, decimal> fundsIn, IDictionary<CalendarPeriod, decimal> fundsOut, DateTime date, IDictionary<CalendarPeriod, decimal> expired, int expiryPeriod);
+        IDictionary<CalendarPeriod, decimal> GetExpiringFunds(IDictionary<CalendarPeriod, decimal> fundsIn, IDictionary<CalendarPeriod, decimal> fundsOut, IDictionary<CalendarPeriod, decimal> expired, int expiryPeriod);
     }
 }

--- a/src/SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests/ExpiredFunds/WhenCalculatingExpiringFunds.cs
+++ b/src/SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests/ExpiredFunds/WhenCalculatingExpiringFunds.cs
@@ -500,12 +500,12 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             var fundsOut = new Dictionary<CalendarPeriod, decimal>
             {
                 {new CalendarPeriod(2018, 11), 12}, 
-                {new CalendarPeriod(2019, 1), 5} //21
+                {new CalendarPeriod(2019, 1), 2} 
             };
             var expiredFunds = new Dictionary<CalendarPeriod, decimal>
             {
                 {new CalendarPeriod(2019, 2), 9},
-                {new CalendarPeriod(2019, 3), 4},//13
+                {new CalendarPeriod(2019, 3), 4},
             };
 
             //Act
@@ -516,7 +516,7 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             Assert.AreEqual(6, actual.Count);
             Assert.AreEqual(9, actual.First().Value);
             Assert.AreEqual(4, actual.Skip(1).First().Value);
-            Assert.AreEqual(4, actual.Skip(2).First().Value);
+            Assert.AreEqual(2, actual.Skip(2).First().Value);
             Assert.AreEqual(0, actual.Skip(3).First().Value);
             Assert.AreEqual(1, actual.Skip(4).First().Value);
             Assert.AreEqual(0, actual.Last().Value);
@@ -556,7 +556,7 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             Assert.AreEqual(7, actual.Count);
             Assert.AreEqual(10, actual.First().Value);
             Assert.AreEqual(9, actual.Skip(1).First().Value);
-            Assert.AreEqual(5, actual.Skip(2).First().Value);
+            Assert.AreEqual(0, actual.Skip(2).First().Value);
             Assert.AreEqual(0, actual.Skip(3).First().Value);
             Assert.AreEqual(1, actual.Skip(4).First().Value);
             Assert.AreEqual(0, actual.Last().Value);

--- a/src/SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests/ExpiredFunds/WhenCalculatingExpiringFunds.cs
+++ b/src/SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests/ExpiredFunds/WhenCalculatingExpiringFunds.cs
@@ -328,7 +328,7 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
         }
 
         [Test]
-        public void Then_If_I_Have_Adjustments_On_My_Funds_In_It_Is_Applied_To_The_Earliest_Funds_In()
+        public void Then_If_I_Have_Adjustments_On_My_Funds_In_It_Is_Applied_In_Descending_Order_To_The_Funds_In()
         {
             //Arrange
             var fundsIn = new Dictionary<CalendarPeriod, decimal>
@@ -351,27 +351,27 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             //Assert
             Assert.IsNotNull(actual);
             Assert.AreEqual(5, actual.Count);
-            Assert.AreEqual(0, actual.First().Value);
-            Assert.AreEqual(4, actual.Skip(1).First().Value);
+            Assert.AreEqual(9, actual.First().Value);
+            Assert.AreEqual(0, actual.Skip(1).First().Value);
             Assert.AreEqual(0, actual.Skip(2).First().Value);
-            Assert.AreEqual(5, actual.Skip(3).First().Value);
+            Assert.AreEqual(0, actual.Skip(3).First().Value);
             Assert.AreEqual(0, actual.Last().Value);
         }
 
 
         [Test]
-        public void Then_If_I_Have_Large_Adjustments_On_My_Funds_In_It_Is_Applied_To_The_Earliest_Funds_In()
+        public void Then_If_I_Have_Large_Adjustments_On_My_Funds_In_It_Is_Applied_In_Descending_Order_For_That_Financial_Year()
         {
             //Arrange
             var fundsIn = new Dictionary<CalendarPeriod, decimal>
             {
                 {new CalendarPeriod(2018, 10), 10},
-                {new CalendarPeriod(2018, 11), 9},
+                {new CalendarPeriod(2018, 11), 29},
                 {new CalendarPeriod(2018, 12), -19},
                 {new CalendarPeriod(2019, 1), 5},
-                {new CalendarPeriod(2019, 2), -5},
+                {new CalendarPeriod(2019, 6), -5},
             };
-            var expiryPeriod = 6;
+            var expiryPeriod = 24;
             var fundsOut = new Dictionary<CalendarPeriod, decimal>
             {
 
@@ -383,10 +383,10 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             //Assert
             Assert.IsNotNull(actual);
             Assert.AreEqual(5, actual.Count);
-            Assert.AreEqual(0, actual.First().Value);
-            Assert.AreEqual(0, actual.Skip(1).First().Value);
+            Assert.AreEqual(10, actual.First().Value);
+            Assert.AreEqual(10, actual.Skip(1).First().Value);
             Assert.AreEqual(0, actual.Skip(2).First().Value);
-            Assert.AreEqual(0, actual.Skip(3).First().Value);
+            Assert.AreEqual(5, actual.Skip(3).First().Value);
             Assert.AreEqual(0, actual.Last().Value);
         }
 
@@ -399,7 +399,7 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
                 {new CalendarPeriod(2018, 12), 10},
                 {new CalendarPeriod(2019, 12), -10}
             };
-            var expiryPeriod = 6;
+            var expiryPeriod = 12;
             var fundsOut = new Dictionary<CalendarPeriod, decimal>
             {
 
@@ -441,10 +441,10 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             //Assert
             Assert.IsNotNull(actual);
             Assert.AreEqual(5, actual.Count);
-            Assert.AreEqual(0, actual.First().Value);
+            Assert.AreEqual(5, actual.First().Value);
             Assert.AreEqual(4, actual.Skip(1).First().Value);
             Assert.AreEqual(0, actual.Skip(2).First().Value);
-            Assert.AreEqual(5, actual.Skip(3).First().Value);
+            Assert.AreEqual(0, actual.Skip(3).First().Value);
             Assert.AreEqual(0, actual.Last().Value);
         }
 
@@ -499,8 +499,8 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             };
             var fundsOut = new Dictionary<CalendarPeriod, decimal>
             {
-                {new CalendarPeriod(2018, 11), 12}, //0
-                {new CalendarPeriod(2019, 1), 3} //2
+                {new CalendarPeriod(2018, 11), 12}, 
+                {new CalendarPeriod(2019, 1), 9} 
             };
             var expiredFunds = new Dictionary<CalendarPeriod, decimal>
             {
@@ -516,9 +516,9 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             Assert.AreEqual(6, actual.Count);
             Assert.AreEqual(9, actual.First().Value);
             Assert.AreEqual(4, actual.Skip(1).First().Value);
-            Assert.AreEqual(2, actual.Skip(2).First().Value);
+            Assert.AreEqual(0, actual.Skip(2).First().Value);
             Assert.AreEqual(0, actual.Skip(3).First().Value);
-            Assert.AreEqual(5, actual.Skip(4).First().Value);
+            Assert.AreEqual(1, actual.Skip(4).First().Value);
             Assert.AreEqual(0, actual.Last().Value);
         }
 
@@ -538,14 +538,14 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             };
             var fundsOut = new Dictionary<CalendarPeriod, decimal>
             {
-                {new CalendarPeriod(2018, 11), 12}, //0
-                {new CalendarPeriod(2019, 1), 3}, //3
-                {new CalendarPeriod(2019, 2), -1} //
+                {new CalendarPeriod(2018, 11), 12}, 
+                {new CalendarPeriod(2019, 1), 10}, 
+                {new CalendarPeriod(2019, 2), -1} 
             };
             var expiredFunds = new Dictionary<CalendarPeriod, decimal>
             {
-                {new CalendarPeriod(2019, 2), 9},
-                {new CalendarPeriod(2019, 3), 4},
+                {new CalendarPeriod(2019, 2), 10},
+                {new CalendarPeriod(2019, 3), 9},
             };
 
             //Act
@@ -554,11 +554,11 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             //Assert
             Assert.IsNotNull(actual);
             Assert.AreEqual(7, actual.Count);
-            Assert.AreEqual(9, actual.First().Value);
-            Assert.AreEqual(4, actual.Skip(1).First().Value);
-            Assert.AreEqual(2, actual.Skip(2).First().Value);
+            Assert.AreEqual(10, actual.First().Value);
+            Assert.AreEqual(9, actual.Skip(1).First().Value);
+            Assert.AreEqual(5, actual.Skip(2).First().Value);
             Assert.AreEqual(0, actual.Skip(3).First().Value);
-            Assert.AreEqual(5, actual.Skip(4).First().Value);
+            Assert.AreEqual(1, actual.Skip(4).First().Value);
             Assert.AreEqual(0, actual.Last().Value);
         }
 
@@ -635,7 +635,7 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             var actual = _expiredFunds.GetExpiringFunds(_fundsIn, fundsOut, expired, expiryPeriod);
 
             //Assert
-            Assert.AreEqual(7500, actual.Skip(3).First().Value);
+            Assert.AreEqual(9500, actual.Skip(3).First().Value);
         }
     }
 }

--- a/src/SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests/ExpiredFunds/WhenCalculatingExpiringFunds.cs
+++ b/src/SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests/ExpiredFunds/WhenCalculatingExpiringFunds.cs
@@ -500,12 +500,12 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             var fundsOut = new Dictionary<CalendarPeriod, decimal>
             {
                 {new CalendarPeriod(2018, 11), 12}, 
-                {new CalendarPeriod(2019, 1), 9} 
+                {new CalendarPeriod(2019, 1), 5} //21
             };
             var expiredFunds = new Dictionary<CalendarPeriod, decimal>
             {
                 {new CalendarPeriod(2019, 2), 9},
-                {new CalendarPeriod(2019, 3), 4},
+                {new CalendarPeriod(2019, 3), 4},//13
             };
 
             //Act
@@ -516,7 +516,7 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds.UnitTests.ExpiredFunds
             Assert.AreEqual(6, actual.Count);
             Assert.AreEqual(9, actual.First().Value);
             Assert.AreEqual(4, actual.Skip(1).First().Value);
-            Assert.AreEqual(0, actual.Skip(2).First().Value);
+            Assert.AreEqual(4, actual.Skip(2).First().Value);
             Assert.AreEqual(0, actual.Skip(3).First().Value);
             Assert.AreEqual(1, actual.Skip(4).First().Value);
             Assert.AreEqual(0, actual.Last().Value);

--- a/src/SFA.DAS.EmployerFinance.ExpiredFunds/ExpiredFunds.cs
+++ b/src/SFA.DAS.EmployerFinance.ExpiredFunds/ExpiredFunds.cs
@@ -40,35 +40,11 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds
 
             CalculateAndApplyAdjustmentsToFundsIn(fundsIn, expiryPeriod);
             
-            var expiredFunds = new Dictionary<CalendarPeriod, decimal>();
-
-            foreach (var fundsInPair in fundsIn.OrderBy(c => c.Key))
-            {
-                var expiryDateOfFundsIn = new DateTime(fundsInPair.Key.Year, fundsInPair.Key.Month, 1).AddMonths(expiryPeriod);
-                var amountDueToExpire = fundsInPair.Value;
-
-
-                var alreadyExpiredAmount = expired?.Keys.FirstOrDefault(c => c.Year.Equals(expiryDateOfFundsIn.Year)
-                                                                         && c.Month.Equals(expiryDateOfFundsIn.Month));
-
-                if (alreadyExpiredAmount != null)
-                {
-                    amountDueToExpire = expired[alreadyExpiredAmount];
-                }
-                else
-                {
-                    amountDueToExpire = amountDueToExpire > 0
-                        ? CalculateExpiryAmount(fundsOut, expiryDateOfFundsIn, amountDueToExpire)
-                        : 0;
-                }
-                
-
-                expiredFunds.Add(new CalendarPeriod(expiryDateOfFundsIn.Year, expiryDateOfFundsIn.Month), amountDueToExpire);
-            }
+            var expiredFunds = CalculatedExpiredFunds(fundsIn, fundsOut, expired, expiryPeriod);
 
             return expiredFunds;
         }
-        
+
         private void CalculatedAndApplyRefundsToFundsIn(Dictionary<CalendarPeriod, decimal> fundsIn, Dictionary<CalendarPeriod, decimal> fundsOut)
         {
             var refunds = fundsOut.Where(c => c.Value < 0).ToDictionary(key => key.Key, value => value.Value);
@@ -190,5 +166,36 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds
 
         }
 
+        private static Dictionary<CalendarPeriod, decimal> CalculatedExpiredFunds(Dictionary<CalendarPeriod, decimal> fundsIn, Dictionary<CalendarPeriod, decimal> fundsOut, Dictionary<CalendarPeriod, decimal> expired,
+            int expiryPeriod)
+        {
+            var expiredFunds = new Dictionary<CalendarPeriod, decimal>();
+
+            foreach (var fundsInPair in fundsIn.OrderBy(c => c.Key))
+            {
+                var expiryDateOfFundsIn = new DateTime(fundsInPair.Key.Year, fundsInPair.Key.Month, 1).AddMonths(expiryPeriod);
+                var amountDueToExpire = fundsInPair.Value;
+
+
+                var alreadyExpiredAmount = expired?.Keys.FirstOrDefault(c => c.Year.Equals(expiryDateOfFundsIn.Year)
+                                                                             && c.Month.Equals(expiryDateOfFundsIn.Month));
+
+                if (alreadyExpiredAmount != null)
+                {
+                    amountDueToExpire = expired[alreadyExpiredAmount];
+                }
+                else
+                {
+                    amountDueToExpire = amountDueToExpire > 0
+                        ? CalculateExpiryAmount(fundsOut, expiryDateOfFundsIn, amountDueToExpire)
+                        : 0;
+                }
+
+
+                expiredFunds.Add(new CalendarPeriod(expiryDateOfFundsIn.Year, expiryDateOfFundsIn.Month), amountDueToExpire);
+            }
+
+            return expiredFunds;
+        }
     }
 }

--- a/src/SFA.DAS.EmployerFinance.ExpiredFunds/ExpiredFunds.cs
+++ b/src/SFA.DAS.EmployerFinance.ExpiredFunds/ExpiredFunds.cs
@@ -7,22 +7,28 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds
 {
     public class ExpiredFunds : IExpiredFunds
     {
-        public decimal GetExpiringFundsByDate(Dictionary<CalendarPeriod, decimal> fundsIn, Dictionary<CalendarPeriod, decimal> fundsOut, DateTime date, Dictionary<CalendarPeriod, decimal> expired, int expiryPeriod)
+        public decimal GetExpiringFundsByDate(
+            IDictionary<CalendarPeriod, decimal> fundsIn, 
+            IDictionary<CalendarPeriod, decimal> fundsOut, 
+            DateTime date, 
+            IDictionary<CalendarPeriod, decimal> expired, int expiryPeriod)
         {
             var expiredFunds = GetExpiringFunds(fundsIn, fundsOut, expired, expiryPeriod);
 
-            if (expiredFunds.Any())
+            if (!expiredFunds.Any())
             {
-                var expiredFundsKey = expiredFunds.Keys.SingleOrDefault(key => key.Year.Equals(date.Year) && key.Month.Equals(date.Month));
-                if (expiredFundsKey != null)
-                {
-                    return expiredFunds[expiredFundsKey];
-                }
+                return 0;
             }
 
-            return 0;
+            var expiredFundsKey = expiredFunds.Keys.SingleOrDefault(key => key.Year.Equals(date.Year) && key.Month.Equals(date.Month));
+            
+            return expiredFundsKey != null ? expiredFunds[expiredFundsKey] : 0;
         }
-        public Dictionary<CalendarPeriod, decimal> GetExpiringFunds(Dictionary<CalendarPeriod, decimal> fundsIn, Dictionary<CalendarPeriod, decimal> fundsOut, Dictionary<CalendarPeriod, decimal> expired, int expiryPeriod)
+        
+        public IDictionary<CalendarPeriod, decimal> GetExpiringFunds(
+            IDictionary<CalendarPeriod, decimal> fundsIn, 
+            IDictionary<CalendarPeriod, decimal> fundsOut, 
+            IDictionary<CalendarPeriod, decimal> expired, int expiryPeriod)
         {
             if (fundsIn == null)
             {
@@ -45,83 +51,100 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds
             return expiredFunds;
         }
 
-        private void CalculatedAndApplyRefundsToFundsIn(Dictionary<CalendarPeriod, decimal> fundsIn, Dictionary<CalendarPeriod, decimal> fundsOut)
+        private static void CalculatedAndApplyRefundsToFundsIn(
+            IDictionary<CalendarPeriod, decimal> fundsIn, 
+            IDictionary<CalendarPeriod, decimal> fundsOut)
         {
-            var refunds = fundsOut.Where(c => c.Value < 0).ToDictionary(key => key.Key, value => value.Value);
-            if (refunds.Any())
+            var refunds = fundsOut.Where(c => c.Value < 0)
+                                  .ToDictionary(key => key.Key, value => value.Value);
+
+            if (!refunds.Any())
             {
-                foreach (var refund in refunds)
+                return;
+            }
+            
+            foreach (var refund in refunds)
+            {
+                if (fundsIn.ContainsKey(refund.Key))
                 {
-                    if (fundsIn.ContainsKey(refund.Key))
-                    {
-                        fundsIn[refund.Key] += refund.Value * -1;
-                    }
-                    else
-                    {
-                        fundsIn.Add(refund.Key,refund.Value*-1);
-                    }
+                    fundsIn[refund.Key] += refund.Value * -1;
+                }
+                else
+                {
+                    fundsIn.Add(refund.Key,refund.Value * -1);
                 }
             }
         }
 
-        private void CalculateAndApplyAdjustmentsToFundsIn(Dictionary<CalendarPeriod, decimal> fundsIn, int expiryPeriod)
+        private static void CalculateAndApplyAdjustmentsToFundsIn(IDictionary<CalendarPeriod, decimal> fundsIn, int expiryPeriod)
         {
-            if (fundsIn.Any(c => c.Value < 0))
+            if (!fundsIn.Any(c => c.Value < 0))
             {
-                var adjustmentsIn = fundsIn.Where(c => c.Value < 0).ToDictionary(key => key.Key, value => value.Value);
+                return;
+            }
+            
+            var adjustmentsIn = fundsIn.Where(c => c.Value < 0)
+                                       .ToDictionary(key => key.Key, value => value.Value);
 
-                foreach (var adjustment in adjustmentsIn.OrderBy(c => c.Key))
+            foreach (var adjustment in adjustmentsIn.OrderBy(c => c.Key))
+            {
+                var adjustmentAmount = adjustment.Value * -1;
+
+                var orderFundsIn = fundsIn.Where(c => c.Value > 0)
+                                          .ToDictionary(c => c.Key, c => c.Value)
+                                          .OrderByDescending(c => c.Key);
+
+                foreach (var fundsInValue in orderFundsIn)
                 {
-                    var adjustmentAmount = adjustment.Value * -1;
-                    
-                    foreach (var fundsInValue in fundsIn.Where(c => c.Value > 0)
-                        .ToDictionary(c => c.Key, c => c.Value)
-                        .OrderByDescending(c => c.Key))
+                    if (!FundsAreInExpiryPeriod(fundsInValue, adjustment.Key, expiryPeriod))
                     {
-                        
-                        if (FundsAreInExpiryPeriod(fundsInValue, adjustment.Key, expiryPeriod))
-                        {
-                            if (fundsInValue.Value >= adjustmentAmount)
-                            {
-                                fundsIn[fundsInValue.Key] = fundsInValue.Value - adjustmentAmount;
-                                break;
-                            }
-
-                            if (fundsInValue.Value < adjustmentAmount)
-                            {
-                                fundsIn[fundsInValue.Key] = 0;
-                                adjustmentAmount = adjustmentAmount - fundsInValue.Value;
-                            }
-                        }
+                        continue;
                     }
+
+                    if (fundsInValue.Value >= adjustmentAmount)
+                    {
+                        fundsIn[fundsInValue.Key] = fundsInValue.Value - adjustmentAmount;
+                        break;
+                    }
+
+                    if (fundsInValue.Value >= adjustmentAmount)
+                    {
+                        continue;
+                    }
+
+                    fundsIn[fundsInValue.Key] = 0;
+                    adjustmentAmount = adjustmentAmount - fundsInValue.Value;
                 }
             }
         }
 
-        private void CalculateAndApplyExpiredFundsToFundsOut(Dictionary<CalendarPeriod, decimal> fundsOut, Dictionary<CalendarPeriod, decimal> expired)
+        private static void CalculateAndApplyExpiredFundsToFundsOut(
+            IDictionary<CalendarPeriod, decimal> fundsOut, 
+            IDictionary<CalendarPeriod, decimal> expired)
         {
-            if (expired!=null && expired.Any(c=>c.Value> 0))
+            if (expired == null || !expired.Any(c => c.Value > 0))
             {
-                foreach (var expiredAmount in expired)
+                return;
+            }
+           
+            foreach (var expiredAmount in expired)
+            {
+                var amount = expiredAmount.Value;
+
+                var fundsOutAvailable = fundsOut
+                    .Where(c => c.Value > 0 && c.Key < expiredAmount.Key)
+                    .ToList();
+
+                foreach (var fundOut in fundsOutAvailable)
                 {
-                    var amount = expiredAmount.Value;
-
-                    var fundsOutAvailable = fundsOut
-                        .Where(c => c.Value > 0 && c.Key < expiredAmount.Key)
-                        .ToList();
-
-                    foreach (var fundOut in fundsOutAvailable)
+                    if (fundOut.Value >= amount)
                     {
-                        if (fundOut.Value >= amount)
-                        {
-                            fundsOut[fundOut.Key] = fundOut.Value - amount;
-                            break;
-                        }
-                        amount = amount - fundOut.Value;
-                        fundsOut[fundOut.Key] = 0;
+                        fundsOut[fundOut.Key] = fundOut.Value - amount;
+                        break;
                     }
-
-                }   
+                    amount = amount - fundOut.Value;
+                    fundsOut[fundOut.Key] = 0;
+                }
             }
         }
 
@@ -152,7 +175,9 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds
             return expiryAmount;
         }
 
-        private static bool FundsAreInExpiryPeriod(KeyValuePair<CalendarPeriod, decimal> fundsInValue, CalendarPeriod adjustment, int expiryPeriod)
+        private static bool FundsAreInExpiryPeriod(
+            KeyValuePair<CalendarPeriod, decimal> fundsInValue,
+            CalendarPeriod adjustment, int expiryPeriod)
         {
             var adjustmentStartPeriod = new DateTime(adjustment.Year, adjustment.Month, 1).AddMonths(expiryPeriod * -1);
             
@@ -161,21 +186,27 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds
                 return false;
             }
 
-            return fundsInValue.Key > new CalendarPeriod(adjustmentStartPeriod.Year, adjustmentStartPeriod.Month) 
-                   && fundsInValue.Key <= adjustment;
+            var fundsInExpiredPeriod = fundsInValue.Key > new CalendarPeriod(adjustmentStartPeriod.Year, adjustmentStartPeriod.Month) 
+                                       && fundsInValue.Key <= adjustment;
+
+            return fundsInExpiredPeriod;
 
         }
 
-        private static Dictionary<CalendarPeriod, decimal> CalculatedExpiredFunds(Dictionary<CalendarPeriod, decimal> fundsIn, Dictionary<CalendarPeriod, decimal> fundsOut, Dictionary<CalendarPeriod, decimal> expired,
+        private static IDictionary<CalendarPeriod, decimal> CalculatedExpiredFunds(
+            IDictionary<CalendarPeriod, decimal> fundsIn, 
+            IDictionary<CalendarPeriod, decimal> fundsOut, 
+            IDictionary<CalendarPeriod, decimal> expired,
             int expiryPeriod)
         {
             var expiredFunds = new Dictionary<CalendarPeriod, decimal>();
 
             foreach (var fundsInPair in fundsIn.OrderBy(c => c.Key))
             {
-                var expiryDateOfFundsIn = new DateTime(fundsInPair.Key.Year, fundsInPair.Key.Month, 1).AddMonths(expiryPeriod);
+                var expiryDateOfFundsIn = new DateTime(fundsInPair.Key.Year, fundsInPair.Key.Month, 1)
+                                                    .AddMonths(expiryPeriod);
+                
                 var amountDueToExpire = fundsInPair.Value;
-
 
                 var alreadyExpiredAmount = expired?.Keys.FirstOrDefault(c => c.Year.Equals(expiryDateOfFundsIn.Year)
                                                                              && c.Month.Equals(expiryDateOfFundsIn.Month));
@@ -190,7 +221,6 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds
                         ? CalculateExpiryAmount(fundsOut, expiryDateOfFundsIn, amountDueToExpire)
                         : 0;
                 }
-
 
                 expiredFunds.Add(new CalendarPeriod(expiryDateOfFundsIn.Year, expiryDateOfFundsIn.Month), amountDueToExpire);
             }

--- a/src/SFA.DAS.EmployerFinance.ExpiredFunds/ExpiredFunds.cs
+++ b/src/SFA.DAS.EmployerFinance.ExpiredFunds/ExpiredFunds.cs
@@ -134,15 +134,15 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds
                         .Where(c => c.Value > 0 && c.Key < expiredAmount.Key)
                         .ToList();
 
-                    foreach (var payment in fundsOutAvailable)
+                    foreach (var fundOut in fundsOutAvailable)
                     {
-                        if (payment.Value >= amount)
+                        if (fundOut.Value >= amount)
                         {
-                            fundsOut[payment.Key] = payment.Value - amount;
+                            fundsOut[fundOut.Key] = fundOut.Value - amount;
                             break;
                         }
-                        amount = amount - payment.Value;
-                        fundsOut[payment.Key] = 0;
+                        amount = amount - fundOut.Value;
+                        fundsOut[fundOut.Key] = 0;
                     }
 
                 }   

--- a/src/SFA.DAS.EmployerFinance.ExpiredFunds/ExpiredFunds.cs
+++ b/src/SFA.DAS.EmployerFinance.ExpiredFunds/ExpiredFunds.cs
@@ -179,31 +179,16 @@ namespace SFA.DAS.EmployerFinance.ExpiredFunds
         private static bool FundsAreInExpiryPeriod(KeyValuePair<CalendarPeriod, decimal> fundsInValue, CalendarPeriod adjustment, int expiryPeriod)
         {
             var adjustmentStartPeriod = new DateTime(adjustment.Year, adjustment.Month, 1).AddMonths(expiryPeriod * -1);
-            var adjustmentEndPeriod = new DateTime(adjustment.Year, adjustment.Month, 1);
-
-            if (!CheckPeriodsAreInSameTaxYear(adjustmentEndPeriod, new DateTime(fundsInValue.Key.Year, fundsInValue.Key.Month, 1)))
+            
+            if (!adjustment.AreSameTaxYear(fundsInValue.Key))
             {
                 return false;
             }
 
-            return new DateTime(fundsInValue.Key.Year, fundsInValue.Key.Month, 1) > adjustmentStartPeriod &&
-                   new DateTime(fundsInValue.Key.Year, fundsInValue.Key.Month, 1) <= adjustmentEndPeriod;
+            return fundsInValue.Key > new CalendarPeriod(adjustmentStartPeriod.Year, adjustmentStartPeriod.Month) 
+                   && fundsInValue.Key <= adjustment;
+
         }
 
-        private static bool CheckPeriodsAreInSameTaxYear(DateTime firstPeriod, DateTime secondPeriod)
-        {
-            var startPeriodTaxYear = GetTaxYearFromDate(firstPeriod);
-
-            var endPeriodTaxYear = GetTaxYearFromDate(secondPeriod);
-
-            return startPeriodTaxYear == endPeriodTaxYear;
-        }
-
-        private static int GetTaxYearFromDate(DateTime firstPeriod)
-        {
-            return firstPeriod.Month >= 1 && firstPeriod.Month <= 4
-                ? firstPeriod.Year + 1
-                : firstPeriod.Year;
-        }
     }
 }


### PR DESCRIPTION
Change to the way that adjustments are applied, they are no longer applied to the earliest available levy credit, but instead work in descending order from the date of the adjustment. Adjustments can only occur in the same tax year.