### PR TITLE
CON-1360 - Change to used funds calc

### DIFF
--- a/src/SFA.DAS.EmployerFinance.Types/Models/ExpiredFunds.cs
+++ b/src/SFA.DAS.EmployerFinance.Types/Models/ExpiredFunds.cs
@@ -38,11 +38,10 @@ namespace SFA.DAS.EmployerFinance.Types.Models
             {
                 throw new ArgumentNullException(nameof(fundsOut));
             }
+            CalculateAndApplyAdjustmentsToTotals(fundsOut);
             
             CalculateAndApplyExpiredFundsToFundsOut(fundsOut, expired, fundsIn, expiryPeriod);
             
-            CalculateAndApplyAdjustmentsToTotals(fundsOut);
-
             CalculateAndApplyAdjustmentsToTotals(fundsIn);
             
             var expiredFunds = CalculatedExpiredFunds(fundsIn, fundsOut, expired, expiryPeriod);
@@ -107,7 +106,7 @@ namespace SFA.DAS.EmployerFinance.Types.Models
 
 
                 var fundsOutAvailable = fundsOut
-                    .Where(c => c.Value > 0 && c.Key < expiredAmount.Key)
+                    .Where(c => c.Value > 0 && c.Key <= expiredAmount.Key)
                     .ToList();
 
                 foreach (var fundOut in fundsOutAvailable)

--- a/src/SFA.DAS.EmployerFinance.UnitTests/Types/Models/ExpiredFundsTests/WhenCalculatingExpiringFunds.cs
+++ b/src/SFA.DAS.EmployerFinance.UnitTests/Types/Models/ExpiredFundsTests/WhenCalculatingExpiringFunds.cs
@@ -683,7 +683,7 @@ namespace SFA.DAS.EmployerFinance.UnitTests.Types.Models.ExpiredFundsTests
             //Assert
             Assert.AreEqual(100, actual.First().Value);
             Assert.AreEqual(439, actual.Skip(1).First().Value);
-            Assert.AreEqual(439, actual.Skip(2).First().Value);
+            Assert.AreEqual(539, actual.Skip(2).First().Value);
             Assert.AreEqual(439, actual.Last().Value);
         }
 

--- a/src/SFA.DAS.EmployerFinance.UnitTests/Types/Models/ExpiredFundsTests/WhenCalculatingExpiringFunds.cs
+++ b/src/SFA.DAS.EmployerFinance.UnitTests/Types/Models/ExpiredFundsTests/WhenCalculatingExpiringFunds.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -717,6 +717,46 @@ namespace SFA.DAS.EmployerFinance.UnitTests.Types.Models.ExpiredFundsTests
             Assert.AreEqual(139, actual.First().Value);
             Assert.AreEqual(539, actual.Skip(1).First().Value);
             Assert.AreEqual(539, actual.Last().Value);
+        }
+
+        [Test]
+        public void Then_If_There_Has_Been_A_Previous_Adjustment_On_An_Already_Expired_Amount_It_Is_Not_Double_Counted()
+        {
+            //Arrange
+            var expiryPeriod = 5;
+            _fundsIn = new Dictionary<CalendarPeriod, decimal>
+            {
+                {new CalendarPeriod(2017, 5), 75},
+                {new CalendarPeriod(2017, 6), 75},
+                {new CalendarPeriod(2017, 7), 75},
+                {new CalendarPeriod(2017, 8), 75},
+                {new CalendarPeriod(2017, 9), 75},
+                {new CalendarPeriod(2017, 10), 75},
+                {new CalendarPeriod(2017, 11), 75},
+                {new CalendarPeriod(2017, 12), 75}
+            };
+            var fundsOut = new Dictionary<CalendarPeriod, decimal>
+            {
+                {new CalendarPeriod(2017,6), 25},
+                {new CalendarPeriod(2017,7), 25},
+                {new CalendarPeriod(2017,8), 50},
+                {new CalendarPeriod(2017,9), -25},
+                {new CalendarPeriod(2017,10), 50},
+                {new CalendarPeriod(2017,11), 25},
+                {new CalendarPeriod(2017,12), 25},
+            };
+            var expired = new Dictionary<CalendarPeriod, decimal>
+            {
+                 {new CalendarPeriod(2017, 10), 0},
+                 {new CalendarPeriod(2017, 11), 0}
+            };
+            
+            //Act
+            var actual = _expiredFunds.GetExpiringFunds(_fundsIn, fundsOut, expired, expiryPeriod);
+            
+            //Assert
+            Assert.AreEqual(50, actual.Skip(2).First().Value);
+            Assert.AreEqual(75, actual.Skip(3).First().Value);
         }
 
         [Test]


### PR DESCRIPTION
When funds have already expired, and there have been adjustments to the funds in, then we need to make sure that those are reflected in the available funds so that they aren't double counted. Also changed the expired funds logic to use the current available month that was available at the time of expiry